### PR TITLE
Initial messagebroker implementation

### DIFF
--- a/handler/actionhandlers.go
+++ b/handler/actionhandlers.go
@@ -71,18 +71,32 @@ func (mb *MessageBroker) handleJoinRoom(p ActionPayload) {
 
 func (mb *MessageBroker) handleCreateUser(p ActionPayload) {
 	// database is already updated from a user user being created
+	// DATABASE
+	// let userName = fetch the user's name from the database
+	userName = "userName"
+
 	responsePayload = ActionResponsePayload{
-		actionType: "message_history",
-		messageHistory: messageHistory
+		actionType: "new_user",
+		userID: p.userID
+		userName: userName
 	}
 	
 	// broadcast new user message to all users logged on
 	for _,cli:= range mb.clientByID {
 		cli.WriteActionQueue() <- responsePayload
 	}
-
 }
 
 func (mb *MessageBroker) handleCreateRoom(p ActionPayload) {
-	// TODO
+
+	responsePayload = ActionResponsePayload{
+		actionType: "new_user",
+		roomID: p.roomID
+		roomName: p.newRoomName
+	}
+	
+	// broadcast new user message to all users logged on
+	for _,cli:= range mb.clientByID {
+		cli.WriteActionQueue() <- responsePayload
+	}
 }

--- a/handler/actionhandlers.go
+++ b/handler/actionhandlers.go
@@ -1,0 +1,88 @@
+/*==============================================================================
+actionhandlers.go - Additional Message Broker Functions: Action Responses
+
+Summary: includes all handlers for actions change_room, send_message, create_dm,
+ join_room, create_user, and create_room. Performs database changes & broadasts
+==============================================================================*/
+//NOTE: all database commands are not completed, and are marked with "DATABASE"
+
+
+package handler
+
+
+func (mb *MessageBroker) handleChangeRoom(p ActionPayload) {
+	// DATABASE update usersrooms to have no unread notifications on p.roomId, p.userId
+
+	// update groupByRoomID
+	delete(mb.groupByRoomID[p.roomID],[p.userID])
+	cli = mb.clientByID[p.userID]
+	cli.RoomID = p.newRoomID
+	mb.groupByRoomID[p.newRoomID],[p.userID]
+
+	// DATABASE fetch list of messages in p.newRoomID
+	// let messageHistory = list of messages type *model.Message (from dataModel)
+	messageHistory = []*model.Message
+
+	responsePayload = ActionResponsePayload{
+		actionType: "message_history",
+		messageHistory: messageHistory
+	}
+
+	cli.WriteActionQueue() <- responsePayload
+}
+
+func (mb *MessageBroker) handleCreateDm(p ActionPayload) {
+	// DATABASE update rooms to have new room of type dm with
+	// users p.dmUserID and p.userID
+	// DATABASE update usersrooms to mark new room as unread
+
+	// return the new roomID and roomName
+	roomID = "roomID"
+	roomName = "roomName"
+
+	responsePayload = ActionResponsePayload{
+		actionType: "create_dm",
+		roomId: roomID,
+		roomName: roomName
+	}
+
+	// send new dm notification to users logged on
+	if cli, ok = mb.clientByID[p.dmUserID]; ok {
+		cli.WriteActionQueue() <- responsePayload
+	}
+}
+
+func (mb *MessageBroker) handleJoinRoom(p ActionPayload) {
+	// DATABASE update usersrooms to have room p.newRoomID and 
+	// p.userID, read
+
+	// DATABASE fetch list of messages in p.newRoomID
+	// let messageHistory = list of messages type *model.Message (from dataModel)
+	messageHistory = []*model.Message
+
+	responsePayload = ActionResponsePayload{
+		actionType: "message_history",
+		messageHistory: messageHistory
+	}
+
+	cli = mb.clientByID[p.userID]
+	cli.WriteActionQueue() <- responsePayload
+}
+
+func (mb *MessageBroker) handleCreateUser(p ActionPayload) {
+	// database is already updated from a user user being created
+	responsePayload = ActionResponsePayload{
+		actionType: "message_history",
+		messageHistory: messageHistory
+	}
+	
+	// broadcast new user message to all users logged on
+	for _,cli:= range mb.clientByID {
+		cli.WriteActionQueue() <- responsePayload
+	}
+
+}
+
+func (mb *MessageBroker) handleCreateRoom(p ActionPayload) {
+	// TODO
+}

--- a/handler/broker.go
+++ b/handler/broker.go
@@ -1,0 +1,167 @@
+/*==============================================================================
+broker.go - Core MessageBroker Functionality
+
+Summary: Creates a MessageBroker, which handles messages along channels from
+Websocket clients to perform broadcasts to other clients or change the database.
+==============================================================================*/
+
+
+package handler
+
+import (
+	"context"
+	"github.com/calvinfeng/sling/util"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// MessageBroker is a central hub that broadcasts all messages and actions, 
+// and sends commands to update the database
+type MessageBroker struct {
+	messageCtx 			echo.Context
+	actionCtx 			echo.Context
+	clientByID 			map[string]Client
+	cancelByID 			map[string]echo.CancelFunc
+	sendMessage 		chan MessagePayload
+	addClient 			chan Client
+	removeClient 		chan Client
+	sendAction 			chan ActionPayload
+	groupByRoomID 	map[string]map[string]Client
+}
+
+var broker *MessageBroker 
+
+// RunBroker : creates a broker and go routine to loop checking for messages 
+// from clients
+func RunBroker(messageCtx echo.Context, actionCtx echo.Context, db *gorm.DB) {
+	broker = &MessageBroker{
+		db: 							db,
+		messageCtx:       messageCtx,
+		actionCtx:        actionCtx,
+		clientByID:    		make(map[string]Client),
+		cancelByID:    		make(map[string]context.CancelFunc),
+		sendMessage:     make(chan MessagePayload),
+		addClient:     	make(chan Client),
+		removeClient:  	make(chan Client),
+		sendAction: 			make(chan ActionPayload),
+		groupByRoomID: 		make(map[string]map[string]Client),
+	}
+
+	go broker.loop()
+}
+
+// loop : spawns appropriate go routines for every new payload along a broker channel
+func (mb *MessageBroker) loop() {
+	for {
+		select {
+		case <-mb.actionCtx.Done():
+			util.LogInfo("Action Stream: Done -- broker loop has terminated")
+			return
+		case <-mb.messageCtx.Done():
+			util.LogInfo("Message Stream: Done --broker loop has terminated")
+			return
+		case c := <-mb.add_client:
+			mb.handleAddClient(c)
+		case c := <-mb.remove_client:
+			mb.handleRemoveClient(c)
+		case b := <-mb.send_message:
+			go mb.handleSendMessage(b)
+		case b := <-mb.user_action:
+			mb.handleSendAction(b)
+		}
+	}
+}
+
+// handleRemoveClient : removes client from broker structures, and cancels ctx
+func (mb *MessageBroker) handleRemoveClient(c Client) {
+	mb.cancelByID[c.ID()]()
+	delete(mb.cancelByID, c.ID())
+	delete(mb.clientByID, c.ID())
+	delete(mb.groupByRoomID[c.RoomID()], c.ID())
+	// TODO: ensure empty maps are deleted for memory saving? 
+}
+ 
+
+// handleAddClient : creates client & child contexts, adds to broker structures
+func (mb *MessageBroker) handleAddClient(c Client) {
+	childMessageCtx, cancel := echo.WithCancel(mb.messageCtx) // TODO : should I keep this as context.WithCancel?
+	childActionCtx, cancel := echo.WithCancel(mb.actionCtx)
+	mb.clientByID[c.ID()] = c
+	mb.cancelByID[c.ID()] = cancel
+
+	if (mb.groupByRoomID[c.RoomID()] == nil){
+		mb.groupByRoomID[c.RoomID()] = make(map[string]Client)
+	}
+	mb.groupByRoomID[c.RoomID()][c.ID()] = c
+
+	c.SetSendMessage(mb.sendMessage)
+	c.SetSendAction(mb.sendAction)
+	c.Activate(childMessageCtx, childActionCtx)
+}
+
+// handleSendMessage : updates database, sends messages and notifications to 
+// clients when the broker recieves a new message
+func (mb *MessageBroker) handleSendMessage(p MessagePayload) {
+	// update database: TODO waiting for database implementations
+
+	// DATABASE add message mb to database
+
+	// DATABASE for all users in room p.roomId, 
+	// whose Ids are not in mb.groupByRoomID[p.roomID], update to unread
+
+	// Let belongToRoom = map of user_ids to booleans that belong to p.roomID DATABASE
+	belongToRoom = make(map[string]bool)
+
+	// update p to be a notification type
+	message = MessageResponsePayload{
+		actionType: "new_message",
+		userID: p.userID,
+		roomID: p.roomID,
+		time: p.time,
+		body: p.body
+	}
+
+	// send live messages to clients logged into this room
+	for _, cli := range mb.groupByRoomID[p.roomID] {
+		select {
+		case cli.WriteMessageQueue() <- message:
+		default: 
+		}
+		belongToRoom[cli.userID()]=false
+	}  
+
+	// update p to be a notification type
+	notification = MessageResponsePayload{
+		actionType: "notification",
+		roomID: p.roomID
+	}
+	
+
+	// send live notifications to logged in clients who belong to this room
+	for userId, active := range belongToRoom {
+		if cli, ok := clientByID[userId]; ok {
+			select {
+			case cli.WriteMessageQueue() <- notification:
+			default: 
+			}
+		}
+	}  
+}
+
+// handleSendAction : checks action type, spawns appropriate goroutine handler
+// NOTE: all action handler are in actionhandlers.go
+func (mb *MessageBroker) handleSendAction(p ActionPayload) {
+	select{
+	case p.actionType == "change_room":
+		go mb.handleChangeRoom(p)
+	case p.actionType == "create_dm":
+		go mb.handleCreateDm(p)
+	case p.actionType == "join_room":
+		go mb.handleJoinRoom(p)
+	case p.actionType == "create_user":
+		go mb.handleCreateUser(p)		
+	case p.actionType == "create_room":	
+		go mb.handleCreateRoom(p)
+	}
+}

--- a/handler/client.go
+++ b/handler/client.go
@@ -1,0 +1,267 @@
+/*==============================================================================
+Client.go - Websocket Client Interface
+
+Summary: Stores information for each connected client in WebSocketClient, 
+Client interface allows communication with the MessageBroker, reads and writes
+to all clients based off of channel communication.
+==============================================================================*/
+
+package handler
+
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/calvinfeng/sling/util"
+	"time"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/gorilla/websocket"
+)
+
+type Client interface {
+	RoomId() string
+	UserId() string
+	Listen()
+	Activate(ctx echo.Context, ctx echo.Context)
+	WriteQueue() chan<-Payload
+	SetBroadcast(chan Payload)
+}
+
+type WebSocketClient struct {
+	roomID string
+	userID string
+	connMessage      *websocket.Conn
+	connAction      *websocket.Conn
+	readMessage      chan json.RawMessage // read next message
+	writeMessage     chan MessageResponsePayload  // write to msg queue next
+	readAction      chan json.RawMessage  // read next message
+	writeAction     chan ActionResponsePayload    // write to msg queue next
+	sendMessage chan MessagePayload
+	sendAction chan ActionPayload
+}
+
+func newWebSocketClient(cMessage *websocket.Conn, cAction *websocket.Conn, userID string, roomID string) Client {
+	return &WebSocketClient{
+		userID:    userID,
+		roomID:    roomID,
+		connMessage:  cAction,
+		connAction:  cAction,
+		readMessage:   make(chan json.RawMessage, 200), // read next message
+		writeMessage:  make(chan MessageResponsePayload, 200),  // write to msg queue next
+		readAction:     make(chan json.RawMessage, 200),  // read next message
+		writeAction:    make(chan ActionResponsePayload, 200),    // write to msg queue next
+		sendMessage: make(chan MessagePayload, 200),
+		sendAction: make(chan ActionPayload, 200),
+	}
+}
+
+// UserID : returns userId, the user_id value in the database related to this client
+func (c *WebSocketClient) UserID() string {
+	return c.userID
+}
+
+// RoomID : returns roomId, the room_id value in the database for this client
+func (c *WebSocketClient) RoomID() string {
+	return c.roomID
+}
+
+// MessageListen : continously checks for new messages along the websocket connection,
+// and forwards new messages along the proper channels 
+func (c *WebSocketClient) MessageListen() {
+	for { 
+		_, bytes, err := c.connMessage.ReadMessage()
+
+		if err != nil &&
+			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
+			return
+		}
+
+		if err != nil {
+			util.LogErr("handler.go conn.RedJSON", err)
+			return
+		}
+
+		c.readMessage <- bytes // no errors; send the message to the read channel
+	}
+}
+
+// ActionListen : continously checks for new messages along the websocket connection,
+// and forwards new messages along the proper channels 
+func (c *WebSocketClient) ActionListen() {
+	for { 
+		_, bytes, err := c.connAction.ReadMessage()
+
+		if err != nil &&
+			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
+			return
+		}
+
+		if err != nil {
+			util.LogErr("handler.go conn.RedJSON", err)
+			return
+		}
+
+		c.readAction <- bytes // no errors; send the message to the read channel
+	}
+}
+
+// Activate : function creates a read and write go routine for this client.
+func (c *WebSocketClient) Activate(messageCtx echo.Context, actionCtx echo.Context) {
+	go c.readMessageLoop(messageCtx)
+	go c.writeMessageLoop(messageCtx)
+	go c.readActionLoop(actionCtx)
+	go c.writeActionLoop(actionCtx)
+}
+
+// WriteMessageQueue : returns channel to write messages to
+func (c *WebSocketClient) WriteMessageQueue() chan<- MessageResponsePayload {
+	return c.writeMessage
+}
+
+// WriteActionQueue : returns channel to write actions to
+func (c *WebSocketClient) WriteActionQueue() chan<- ActionResponsePayload {
+	return c.writeAction
+}
+
+// SetSendMessage : sets channel for sending messages to message broker
+func (c *WebSocketClient) SetSendMessage(ch chan MessagePayload) {
+	c.sendMessage = ch
+}
+
+// SetSendAction : sets channel for sending actions to message broker
+func (c *WebSocketClient) SetSendAction(ch chan ActionPayload) {
+	c.sendAction = ch
+}
+
+// readMessageLoop : continuously reads from connMessage for new messages, and
+// forwards them to the message broker 
+func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
+	c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+	c.connMessage.SetPongHandler(func(s string) error {
+		c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+		return nil
+	})
+
+	for {
+		select {
+		case <-ctx.Done(): // read loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated read message loop", c.id))
+			return
+
+		case bytes := <-c.readMessage: // read bytes detected in channel
+			c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+			p := MessagePayload{}
+			util.LogInfo(string(bytes))
+
+			err := json.Unmarshal(bytes, &p) // converts json to payload
+			if err != nil {
+				util.LogErr("readMessageLoop: json.Unmarshall", err)
+				continue
+			}
+			c.sendMessage <- p
+		}
+	}
+}
+
+// readActionLoop : continuously reads from connAction for new actions, and
+// forwards them to the message broker 
+func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
+	c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+	c.connAction.SetPongHandler(func(s string) error {
+		c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+		return nil
+	})
+
+	for {
+		select {
+		case <-ctx.Done(): // read loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated read action loop", c.id))
+			return
+
+		case bytes := <-c.readAction: // read bytes detected in channel
+			c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+			p := ActionPayload{}
+			util.LogInfo(string(bytes))
+
+			err := json.Unmarshal(bytes, &p) // converts json to payload
+			if err != nil {
+				util.LogErr("readActionLoop: json.Unmarshall", err)
+				continue
+			}
+			c.sendAction <- p
+		}
+	}
+
+	// writeMessageLoop : writes messages to client if a message payload is passed
+	// along c.writeMessage
+	func (c *WebSocketClient) writeMessageLoop(ctx context.Context) {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+	
+		for {
+			select {
+			case <-ctx.Done(): // write loop is closed
+				util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
+				return
+			case p := <-c.writeMessage: // message broker wants to write to client
+				c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+				bytes, err := json.Marshal(p)
+				if err != nil {
+					util.LogErr("writeMessageLoop json.Marshall", err)
+					continue
+				}
+	
+				err = c.connMessage.WriteMessage(websocket.TextMessage, bytes)
+				if err != nil {
+					return
+				}
+	
+			case <-ticker.C: // send a ping to the connection if the ticker signals
+				c.connMessage.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				err := c.connMessage.WriteMessage(websocket.PingMessage, []byte{})
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+
+	// writeActionLoop : writes actions to client if a action payload is passed
+	// along c.writeAction
+	func (c *WebSocketClient) writeActionLoop(ctx context.Context) {
+		ticker := time.NewTicker(1 * time.Second)
+		defer ticker.Stop()
+	
+		for {
+			select {
+			case <-ctx.Done(): // write loop is closed
+				util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
+				return
+			case p := <-c.writeAction: // message broker wants to write to client
+				c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+				bytes, err := json.Marshal(p)
+				if err != nil {
+					util.LogErr("writeActionLoop json.Marshall", err)
+					continue
+				}
+	
+				err = c.connAction.WriteMessage(websocket.TextMessage, bytes)
+				if err != nil {
+					return
+				}
+	
+			case <-ticker.C: // send a ping to the connection if the ticker signals
+				c.connAction.SetWriteDeadline(time.Now().Add(5 * time.Second))
+				err := c.connAction.WriteMessage(websocket.PingMessage, []byte{})
+				if err != nil {
+					return
+				}
+			}
+		}
+	}
+
+

--- a/handler/payloads.go
+++ b/handler/payloads.go
@@ -1,0 +1,53 @@
+/*==============================================================================
+payloads.go - Defines Payload Structures
+
+Summary: Defines payloads for channel communication ingoing and outgoing between
+the MessageBroker and WebsocketClient s
+==============================================================================*/
+
+package handler
+
+/************* Client to MessageBroker payload Types ******************/
+
+// MessagePayload holds the message content to be communicated from the
+// client frontend, to the server and message broker
+type MessagePayload struct {
+	userID string `json:"userID"`
+	roomID string `json:"roomID"`
+	time   string `json:"time"`
+	body   string `json:"body"`
+}
+
+// ActionPayload holds the action content to be communicated from the
+// client frontend, to the server and message broker
+type ActionPayload struct {
+	actionType  string `json:"actionType"`
+	userID      string `json:"userID"`
+	roomID      string `json:"roomID"`
+	newRoomID   string `json:"newRoomID"`
+	dmUserID    string `json:"dmUserID"`
+	newRoomName string `json:"newRoomName"`
+}
+
+/***************** MessageBroker to Client payload Types *****************/
+
+// MessageResponsePayload holds the message content to be communicated from the
+// message broker to users logged on
+type MessageResponsePayload struct {
+	messageType string `json:"messageType"`
+	userID      string `json:"userID"`
+	roomID      string `json:"roomID"`
+	time        string `json:"time"`
+	body        string `json:"body"`
+}
+
+// ActionResponsePayload holds the message content to be communicated from the
+// message broker to users logged on
+type ActionResponsePayload struct {
+	actionType     string           `json:"actionType"`
+	userID         string           `json:"userID"`
+	roomID         string           `json:"roomID"`
+	userName       string           `json:"userName"`
+	roomName       string           `json:"roomName"`
+	messageHistory []*model.Message `json:"messageHistory"`
+}


### PR DESCRIPTION
Completed MessageBroker Implementation, WebSocket Client implementation, with the following caveats:

1. model.Message and model.User are assumed structures that are/will be created in the model folder of this repo ( @zpl0310 is working on this). References to this are used in broker.go and actionhandler.go
2. Database queries and updates are not 'real'; instead, a dummy value is given at instances where database use is necessary. This is to be updated based off of the migrations folder in the future.

TODO: The runserver.go file will need to be modified so that both WebSocket connections can be passed to a single client object to fit the client interface requirements.
