### PR TITLE
Connect message broker

### DIFF
--- a/cmd/run_server.go
+++ b/cmd/run_server.go
@@ -1,17 +1,17 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-
 	"github.com/calvinfeng/sling/handler"
+	"github.com/gorilla/websocket"
 	"github.com/jinzhu/gorm"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/spf13/cobra"
-
+	"io"
+	"net/http"
+	"os"
 	// Postgres database driver
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -55,16 +55,16 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	srv.GET("/api/rooms", handler.GetRoomsHandler(conn), handler.NewTokenAuthMiddleware(conn))
 
-	messageStreamHandler, err := handler.GetMessageStreamHandler(&websocket.Upgrader{})
-	if err != nil {
-		util.LogErr("Mesage Stream Handler creation error", err)
-		return err
-	}
-	actionStreamHandler, err := handler.GetActionStreamHandler(&websocket.Upgrader{})
-	if err != nil {
-		util.LogErr("Action Stream Handler creation error", err)
-		return err
-	}
+	messageStreamHandler := handler.GetMessageStreamHandler(&websocket.Upgrader{})
+	// if err != nil {
+	// 	util.LogErr("Mesage Stream Handler creation error", err)
+	// 	return err
+	// }
+	actionStreamHandler := handler.GetActionStreamHandler(&websocket.Upgrader{})
+	// if err != nil {
+	// 	util.LogErr("Action Stream Handler creation error", err)
+	// 	return err
+	// }
 
 	streams := srv.Group("api/stream")
 	streams.GET("/messages", messageStreamHandler)
@@ -78,6 +78,6 @@ func runServer(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func setupBroker(conn) {
-	RunBroker(context.Background(), conn)
+func setupBroker(conn *gorm.DB) {
+	handler.RunBroker(context.Background(), conn)
 }

--- a/handler/broker.go
+++ b/handler/broker.go
@@ -1,165 +1,166 @@
-// /*==============================================================================
-// broker.go - Core MessageBroker Functionality
+/*==============================================================================
+broker.go - Core MessageBroker Functionality
 
-// Summary: Creates a MessageBroker, which handles messages along channels from
-// Websocket clients to perform broadcasts to other clients or change the database.
-// ==============================================================================*/
-// //NOTE: all database commands are not completed, and are marked with "DATABASE"
+Summary: Creates a MessageBroker, which handles messages along channels from
+Websocket clients to perform broadcasts to other clients or change the database.
+==============================================================================*/
+//NOTE: all database commands are not completed, and are marked with "DATABASE"
 
 package handler
 
-// import (
-// 	"context"
-// 	"github.com/calvinfeng/sling/util"
-// 	"github.com/gorilla/websocket"
-// 	"github.com/labstack/echo/v4"
-// 	"github.com/labstack/echo/v4/middleware"
-// )
+import (
+	"context"
+	_ "github.com/calvinfeng/sling/model"
+	"github.com/calvinfeng/sling/util"
+	"github.com/gorilla/websocket"
+	"github.com/jinzhu/gorm"
+	// "github.com/labstack/echo/v4"
+	// _ "github.com/labstack/echo/v4/middleware"
+)
 
-// // MessageBroker is a central hub that broadcasts all messages and actions,
-// // and sends commands to update the database
-// type MessageBroker struct {
-// 	messageCtx 			echo.Context
-// 	actionCtx 			echo.Context
-// 	clientByID 			map[string]Client
-// 	cancelByID 			map[string]echo.CancelFunc
-// 	sendMessage 		chan MessagePayload
-// 	addClient 			chan Client
-// 	removeClient 		chan Client
-// 	sendAction 			chan ActionPayload
-// 	groupByRoomID 	map[string]map[string]Client
-// }
+// MessageBroker is a central hub that broadcasts all messages and actions,
+// and sends commands to update the database
+type MessageBroker struct {
+	db                 *gorm.DB
+	ctx                context.Context
+	clientByID         map[string]Client
+	cancelByID         map[string]context.CancelFunc
+	sendMessage        chan MessagePayload
+	addClient          chan Client
+	removeClient       chan Client
+	sendAction         chan ActionPayload
+	groupByRoomID      map[string]map[string]Client
+	websocketsByUserID map[string]chan *websocket.Conn
+}
 
-// var broker *MessageBroker
+var broker *MessageBroker
 
-// // RunBroker : creates a broker and go routine to loop checking for messages
-// // from clients
-// func RunBroker(messageCtx echo.Context, actionCtx echo.Context, db *gorm.DB) {
-// 	broker = &MessageBroker{
-// 		db: 							db,
-// 		messageCtx:       messageCtx,
-// 		actionCtx:        actionCtx,
-// 		clientByID:    		make(map[string]Client),
-// 		cancelByID:    		make(map[string]context.CancelFunc),
-// 		sendMessage:     make(chan MessagePayload),
-// 		addClient:     	make(chan Client),
-// 		removeClient:  	make(chan Client),
-// 		sendAction: 			make(chan ActionPayload),
-// 		groupByRoomID: 		make(map[string]map[string]Client),
-// 	}
+// RunBroker : creates a broker and go routine to loop checking for messages
+// from clients
+func RunBroker(ctx context.Context, db *gorm.DB) {
+	broker = &MessageBroker{
+		db:                 db,
+		ctx:                ctx,
+		clientByID:         make(map[string]Client),
+		cancelByID:         make(map[string]context.CancelFunc),
+		sendMessage:        make(chan MessagePayload),
+		addClient:          make(chan Client),
+		removeClient:       make(chan Client),
+		sendAction:         make(chan ActionPayload),
+		groupByRoomID:      make(map[string]map[string]Client),
+		websocketsByUserID: make(map[string]chan *websocket.Conn),
+	}
 
-// 	go broker.loop()
-// }
+	go broker.loop()
+}
 
-// // loop : spawns appropriate go routines for every new payload along a broker channel
-// func (mb *MessageBroker) loop() {
-// 	for {
-// 		select {
-// 		case <-mb.actionCtx.Done():
-// 			util.LogInfo("Action Stream: Done -- broker loop has terminated")
-// 			return
-// 		case <-mb.messageCtx.Done():
-// 			util.LogInfo("Message Stream: Done --broker loop has terminated")
-// 			return
-// 		case c := <-mb.add_client:
-// 			mb.handleAddClient(c)
-// 		case c := <-mb.remove_client:
-// 			mb.handleRemoveClient(c)
-// 		case b := <-mb.send_message:
-// 			go mb.handleSendMessage(b)
-// 		case b := <-mb.user_action:
-// 			mb.handleSendAction(b)
-// 		}
-// 	}
-// }
+// loop : spawns appropriate go routines for every new payload along a broker channel
+func (mb *MessageBroker) loop() {
+	for {
+		select {
+		case <-mb.ctx.Done():
+			util.LogInfo("Stream: Done -- broker loop has terminated")
+			return
+		case c := <-mb.addClient:
+			mb.handleAddClient(c)
+		case c := <-mb.removeClient:
+			mb.handleRemoveClient(c)
+		case b := <-mb.sendMessage:
+			go mb.handleSendMessage(b)
+		case b := <-mb.sendAction:
+			mb.handleSendAction(b)
+		}
+	}
+}
 
-// // handleRemoveClient : removes client from broker structures, and cancels ctx
-// func (mb *MessageBroker) handleRemoveClient(c Client) {
-// 	mb.cancelByID[c.ID()]()
-// 	delete(mb.cancelByID, c.ID())
-// 	delete(mb.clientByID, c.ID())
-// 	delete(mb.groupByRoomID[c.RoomID()], c.ID())
-// 	// TODO: ensure empty maps are deleted for memory saving?
-// }
+// handleRemoveClient : removes client from broker structures, and cancels ctx
+func (mb *MessageBroker) handleRemoveClient(c Client) {
+	mb.cancelByID[c.UserID()]()
+	delete(mb.cancelByID, c.UserID())
+	delete(mb.clientByID, c.UserID())
+	if c.RoomID() != nil {
+		delete(mb.groupByRoomID[c.RoomID()], c.UserID())
+	}
+	// TODO: ensure empty maps are deleted for memory saving?
+}
 
-// // handleAddClient : creates client & child contexts, adds to broker structures
-// func (mb *MessageBroker) handleAddClient(c Client) {
-// 	childMessageCtx, cancel := echo.WithCancel(mb.messageCtx) // TODO : should I keep this as context.WithCancel?
-// 	childActionCtx, cancel := echo.WithCancel(mb.actionCtx)
-// 	mb.clientByID[c.ID()] = c
-// 	mb.cancelByID[c.ID()] = cancel
+// handleAddClient : creates client & child contexts, adds to broker structures
+func (mb *MessageBroker) handleAddClient(c Client) {
+	ctx, cancel := context.WithCancel(mb.messageCtx) // TODO : should I keep this as context.WithCancel?
+	mb.clientByID[c.ID()] = c
+	mb.cancelByID[c.ID()] = cancel
 
-// 	if (mb.groupByRoomID[c.RoomID()] == nil){
-// 		mb.groupByRoomID[c.RoomID()] = make(map[string]Client)
-// 	}
-// 	mb.groupByRoomID[c.RoomID()][c.ID()] = c
+	// if mb.groupByRoomID[c.RoomID()] == nil {
+	// 	mb.groupByRoomID[c.RoomID()] = make(map[string]Client)
+	// }
+	// mb.groupByRoomID[c.RoomID()][c.ID()] = c
 
-// 	c.SetSendMessage(mb.sendMessage)
-// 	c.SetSendAction(mb.sendAction)
-// 	c.Activate(childMessageCtx, childActionCtx)
-// }
+	c.SetSendMessage(mb.sendMessage)
+	c.SetSendAction(mb.sendAction)
+	c.Activate(ctx)
+}
 
-// // handleSendMessage : updates database, sends messages and notifications to
-// // clients when the broker recieves a new message
-// func (mb *MessageBroker) handleSendMessage(p MessagePayload) {
-// 	// update database: TODO waiting for database implementations
+// handleSendMessage : updates database, sends messages and notifications to
+// clients when the broker recieves a new message
+func (mb *MessageBroker) handleSendMessage(p MessagePayload) {
+	// update database: TODO waiting for database implementations
 
-// 	// DATABASE add message mb to database
+	// DATABASE add message mb to database
 
-// 	// DATABASE for all users in room p.roomId,
-// 	// whose Ids are not in mb.groupByRoomID[p.roomID], update to unread
+	// DATABASE for all users in room p.roomId,
+	// whose Ids are not in mb.groupByRoomID[p.roomID], update to unread
 
-// 	// Let belongToRoom = map of user_ids to booleans that belong to p.roomID DATABASE
-// 	belongToRoom = make(map[string]bool)
+	// Let belongToRoom = map of user_ids to booleans that belong to p.roomID DATABASE
+	belongToRoom = make(map[string]bool)
 
-// 	// update p to be a notification type
-// 	message = MessageResponsePayload{
-// 		actionType: "new_message",
-// 		userID: p.userID,
-// 		roomID: p.roomID,
-// 		time: p.time,
-// 		body: p.body
-// 	}
+	// update p to be a notification type
+	message = MessageResponsePayload{
+		actionType: "new_message",
+		userID:     p.userID,
+		roomID:     p.roomID,
+		time:       p.time,
+		body:       p.body,
+	}
 
-// 	// send live messages to clients logged into this room
-// 	for _, cli := range mb.groupByRoomID[p.roomID] {
-// 		select {
-// 		case cli.WriteMessageQueue() <- message:
-// 		default:
-// 		}
-// 		belongToRoom[cli.userID()]=false
-// 	}
+	// send live messages to clients logged into this room
+	for _, cli := range mb.groupByRoomID[p.roomID] {
+		select {
+		case cli.WriteMessageQueue() <- message:
+		default:
+		}
+		belongToRoom[cli.userID()] = false
+	}
 
-// 	// update p to be a notification type
-// 	notification = MessageResponsePayload{
-// 		actionType: "notification",
-// 		roomID: p.roomID
-// 	}
+	// update p to be a notification type
+	notification = MessageResponsePayload{
+		actionType: "notification",
+		roomID:     p.roomID,
+	}
 
-// 	// send live notifications to logged in clients who belong to this room
-// 	for userId, active := range belongToRoom {
-// 		if cli, ok := clientByID[userId]; ok {
-// 			select {
-// 			case cli.WriteMessageQueue() <- notification:
-// 			default:
-// 			}
-// 		}
-// 	}
-// }
+	// send live notifications to logged in clients who belong to this room
+	for userId, active := range belongToRoom {
+		if cli, ok := clientByID[userId]; ok {
+			select {
+			case cli.WriteMessageQueue() <- notification:
+			default:
+			}
+		}
+	}
+}
 
-// // handleSendAction : checks action type, spawns appropriate goroutine handler
-// // NOTE: all action handler are in actionhandlers.go
-// func (mb *MessageBroker) handleSendAction(p ActionPayload) {
-// 	select{
-// 	case p.actionType == "change_room":
-// 		go mb.handleChangeRoom(p)
-// 	case p.actionType == "create_dm":
-// 		go mb.handleCreateDm(p)
-// 	case p.actionType == "join_room":
-// 		go mb.handleJoinRoom(p)
-// 	case p.actionType == "create_user":
-// 		go mb.handleCreateUser(p)
-// 	case p.actionType == "create_room":
-// 		go mb.handleCreateRoom(p)
-// 	}
-// }
+// handleSendAction : checks action type, spawns appropriate goroutine handler
+// NOTE: all action handler are in actionhandlers.go
+func (mb *MessageBroker) handleSendAction(p ActionPayload) {
+	select {
+	case p.actionType == "change_room":
+		go mb.handleChangeRoom(p)
+	case p.actionType == "create_dm":
+		go mb.handleCreateDm(p)
+	case p.actionType == "join_room":
+		go mb.handleJoinRoom(p)
+	case p.actionType == "create_user":
+		go mb.handleCreateUser(p)
+	case p.actionType == "create_room":
+		go mb.handleCreateRoom(p)
+	}
+}

--- a/handler/client.go
+++ b/handler/client.go
@@ -8,257 +8,267 @@ to all clients based off of channel communication.
 
 package handler
 
-// import (
-// 	"context"
-// 	"encoding/json"
-// 	"fmt"
-// 	"github.com/calvinfeng/sling/util"
-// 	"time"
-// 	"github.com/labstack/echo/v4"
-// 	"github.com/labstack/echo/v4/middleware"
-// 	"github.com/gorilla/websocket"
-// )
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/calvinfeng/sling/util"
+	"github.com/gorilla/websocket"
+	"github.com/labstack/echo/v4"
+	"time"
+)
 
-// type Client interface {
-// 	RoomId() string
-// 	UserId() string
-// 	Listen()
-// 	Activate(ctx echo.Context, ctx echo.Context)
-// 	WriteQueue() chan<-Payload
-// 	SetBroadcast(chan Payload)
-// }
+type Client interface {
+	RoomId() string
+	UserId() string
+	MessageListen()
+	ActionListen()
+	Activate(messageCtx echo.Context, actionCtx echo.Context)
+	WriteMessageQueue() chan<- MessagePayload
+	WriteActionQueue() chan<- ActionPayload
+	SetSendAction(chan ActionPayload)
+	SetSendMessage(chan MessagePayload)
+	SetRoomID(string)
+}
 
-// type WebSocketClient struct {
-// 	roomID string
-// 	userID string
-// 	connMessage      *websocket.Conn
-// 	connAction      *websocket.Conn
-// 	readMessage      chan json.RawMessage // read next message
-// 	writeMessage     chan MessageResponsePayload  // write to msg queue next
-// 	readAction      chan json.RawMessage  // read next message
-// 	writeAction     chan ActionResponsePayload    // write to msg queue next
-// 	sendMessage chan MessagePayload
-// 	sendAction chan ActionPayload
-// }
+type WebSocketClient struct {
+	roomID       string
+	userID       string
+	connMessage  *websocket.Conn
+	connAction   *websocket.Conn
+	readMessage  chan json.RawMessage        // read next message
+	writeMessage chan MessageResponsePayload // write to msg queue next
+	readAction   chan json.RawMessage        // read next message
+	writeAction  chan ActionResponsePayload  // write to msg queue next
+	sendMessage  chan MessagePayload
+	sendAction   chan ActionPayload
+}
 
-// func newWebSocketClient(cMessage *websocket.Conn, cAction *websocket.Conn, userID string, roomID string) Client {
-// 	return &WebSocketClient{
-// 		userID:    userID,
-// 		roomID:    roomID,
-// 		connMessage:  cAction,
-// 		connAction:  cAction,
-// 		readMessage:   make(chan json.RawMessage, 200), // read next message
-// 		writeMessage:  make(chan MessageResponsePayload, 200),  // write to msg queue next
-// 		readAction:     make(chan json.RawMessage, 200),  // read next message
-// 		writeAction:    make(chan ActionResponsePayload, 200),    // write to msg queue next
-// 		sendMessage: make(chan MessagePayload, 200),
-// 		sendAction: make(chan ActionPayload, 200),
-// 	}
-// }
+func newWebSocketClient(messageConn *websocket.Conn, actionConn *websocket.Conn, userID string) Client {
+	return &WebSocketClient{
+		userID:       userID,
+		roomID:       nil,
+		connMessage:  messageConn,
+		connAction:   actionConn,
+		readMessage:  make(chan json.RawMessage, 200),        // read next message
+		writeMessage: make(chan MessageResponsePayload, 200), // write to msg queue next
+		readAction:   make(chan json.RawMessage, 200),        // read next message
+		writeAction:  make(chan ActionResponsePayload, 200),  // write to msg queue next
+		sendMessage:  make(chan MessagePayload, 200),
+		sendAction:   make(chan ActionPayload, 200),
+	}
+}
 
-// // UserID : returns userId, the user_id value in the database related to this client
-// func (c *WebSocketClient) UserID() string {
-// 	return c.userID
-// }
+// UserID : returns userId, the user_id value in the database related to this client
+func (c *WebSocketClient) UserID() string {
+	return c.userID
+}
 
-// // RoomID : returns roomId, the room_id value in the database for this client
-// func (c *WebSocketClient) RoomID() string {
-// 	return c.roomID
-// }
+// RoomID : returns roomId, the room_id value in the database for this client
+func (c *WebSocketClient) RoomID() string {
+	return c.roomID
+}
 
-// // MessageListen : continously checks for new messages along the websocket connection,
-// // and forwards new messages along the proper channels
-// func (c *WebSocketClient) MessageListen() {
-// 	for {
-// 		_, bytes, err := c.connMessage.ReadMessage()
+func (c *WebSocketClient) SetRoomID(roomID string) {
+	c.roomID = roomID
+}
 
-// 		if err != nil &&
-// 			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-// 			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
-// 			return
-// 		}
+// MessageListen : continously checks for new messages along the websocket connection,
+// and forwards new messages along the proper channels
+func (c *WebSocketClient) MessageListen(wg sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		_, bytes, err := c.connMessage.ReadMessage()
 
-// 		if err != nil {
-// 			util.LogErr("handler.go conn.RedJSON", err)
-// 			return
-// 		}
+		if err != nil &&
+			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
+			return
+		}
 
-// 		c.readMessage <- bytes // no errors; send the message to the read channel
-// 	}
-// }
+		if err != nil {
+			util.LogErr("handler.go conn.RedJSON", err)
+			return
+		}
 
-// // ActionListen : continously checks for new messages along the websocket connection,
-// // and forwards new messages along the proper channels
-// func (c *WebSocketClient) ActionListen() {
-// 	for {
-// 		_, bytes, err := c.connAction.ReadMessage()
+		c.readMessage <- bytes // no errors; send the message to the read channel
+	}
+}
 
-// 		if err != nil &&
-// 			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-// 			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
-// 			return
-// 		}
+// ActionListen : continously checks for new messages along the websocket connection,
+// and forwards new messages along the proper channels
+func (c *WebSocketClient) ActionListen(wg sync.WaitGroup) {
+	defer wg.Done()
+	for {
+		_, bytes, err := c.connAction.ReadMessage()
 
-// 		if err != nil {
-// 			util.LogErr("handler.go conn.RedJSON", err)
-// 			return
-// 		}
+		if err != nil &&
+			websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
+			util.LogInfo(fmt.Sprintf("Client %s is listening", c.id))
+			return
+		}
 
-// 		c.readAction <- bytes // no errors; send the message to the read channel
-// 	}
-// }
+		if err != nil {
+			util.LogErr("handler.go conn.RedJSON", err)
+			return
+		}
 
-// // Activate : function creates a read and write go routine for this client.
-// func (c *WebSocketClient) Activate(messageCtx echo.Context, actionCtx echo.Context) {
-// 	go c.readMessageLoop(messageCtx)
-// 	go c.writeMessageLoop(messageCtx)
-// 	go c.readActionLoop(actionCtx)
-// 	go c.writeActionLoop(actionCtx)
-// }
+		c.readAction <- bytes // no errors; send the message to the read channel
+	}
+}
 
-// // WriteMessageQueue : returns channel to write messages to
-// func (c *WebSocketClient) WriteMessageQueue() chan<- MessageResponsePayload {
-// 	return c.writeMessage
-// }
+// Activate : function creates a read and write go routine for this client.
+func (c *WebSocketClient) Activate(ctx context.Context) {
+	go c.readMessageLoop(ctx)
+	go c.writeMessageLoop(ctx)
+	go c.readActionLoop(ctx)
+	go c.writeActionLoop(ctx)
+}
 
-// // WriteActionQueue : returns channel to write actions to
-// func (c *WebSocketClient) WriteActionQueue() chan<- ActionResponsePayload {
-// 	return c.writeAction
-// }
+// WriteMessageQueue : returns channel to write messages to
+func (c *WebSocketClient) WriteMessageQueue() chan<- MessageResponsePayload {
+	return c.writeMessage
+}
 
-// // SetSendMessage : sets channel for sending messages to message broker
-// func (c *WebSocketClient) SetSendMessage(ch chan MessagePayload) {
-// 	c.sendMessage = ch
-// }
+// WriteActionQueue : returns channel to write actions to
+func (c *WebSocketClient) WriteActionQueue() chan<- ActionResponsePayload {
+	return c.writeAction
+}
 
-// // SetSendAction : sets channel for sending actions to message broker
-// func (c *WebSocketClient) SetSendAction(ch chan ActionPayload) {
-// 	c.sendAction = ch
-// }
+// SetSendMessage : sets channel for sending messages to message broker
+func (c *WebSocketClient) SetSendMessage(ch chan MessagePayload) {
+	c.sendMessage = ch
+}
 
-// // readMessageLoop : continuously reads from connMessage for new messages, and
-// // forwards them to the message broker
-// func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
-// 	c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 	c.connMessage.SetPongHandler(func(s string) error {
-// 		c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 		return nil
-// 	})
+// SetSendAction : sets channel for sending actions to message broker
+func (c *WebSocketClient) SetSendAction(ch chan ActionPayload) {
+	c.sendAction = ch
+}
 
-// 	for {
-// 		select {
-// 		case <-ctx.Done(): // read loop is closed
-// 			util.LogInfo(fmt.Sprintf("client %s has terminated read message loop", c.id))
-// 			return
+// readMessageLoop : continuously reads from connMessage for new messages, and
+// forwards them to the message broker
+func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
+	c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+	c.connMessage.SetPongHandler(func(s string) error {
+		c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+		return nil
+	})
 
-// 		case bytes := <-c.readMessage: // read bytes detected in channel
-// 			c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 			p := MessagePayload{}
-// 			util.LogInfo(string(bytes))
+	for {
+		select {
+		case <-ctx.Done(): // read loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated read message loop", c.id))
+			return
 
-// 			err := json.Unmarshal(bytes, &p) // converts json to payload
-// 			if err != nil {
-// 				util.LogErr("readMessageLoop: json.Unmarshall", err)
-// 				continue
-// 			}
-// 			c.sendMessage <- p
-// 		}
-// 	}
-// }
+		case bytes := <-c.readMessage: // read bytes detected in channel
+			c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+			p := MessagePayload{}
+			util.LogInfo(string(bytes))
 
-// // readActionLoop : continuously reads from connAction for new actions, and
-// // forwards them to the message broker
-// func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
-// 	c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 	c.connAction.SetPongHandler(func(s string) error {
-// 		c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 		return nil
-// 	})
+			err := json.Unmarshal(bytes, &p) // converts json to payload
+			if err != nil {
+				util.LogErr("readMessageLoop: json.Unmarshall", err)
+				continue
+			}
+			c.sendMessage <- p
+		}
+	}
+}
 
-// 	for {
-// 		select {
-// 		case <-ctx.Done(): // read loop is closed
-// 			util.LogInfo(fmt.Sprintf("client %s has terminated read action loop", c.id))
-// 			return
+// readActionLoop : continuously reads from connAction for new actions, and
+// forwards them to the message broker
+func (c *WebSocketClient) readMessageLoop(ctx context.Context) {
+	c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+	c.connAction.SetPongHandler(func(s string) error {
+		c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+		return nil
+	})
 
-// 		case bytes := <-c.readAction: // read bytes detected in channel
-// 			c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 			p := ActionPayload{}
-// 			util.LogInfo(string(bytes))
+	for {
+		select {
+		case <-ctx.Done(): // read loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated read action loop", c.id))
+			return
 
-// 			err := json.Unmarshal(bytes, &p) // converts json to payload
-// 			if err != nil {
-// 				util.LogErr("readActionLoop: json.Unmarshall", err)
-// 				continue
-// 			}
-// 			c.sendAction <- p
-// 		}
-// 	}
+		case bytes := <-c.readAction: // read bytes detected in channel
+			c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+			p := ActionPayload{}
+			util.LogInfo(string(bytes))
 
-// 	// writeMessageLoop : writes messages to client if a message payload is passed
-// 	// along c.writeMessage
-// 	func (c *WebSocketClient) writeMessageLoop(ctx context.Context) {
-// 		ticker := time.NewTicker(1 * time.Second)
-// 		defer ticker.Stop()
+			err := json.Unmarshal(bytes, &p) // converts json to payload
+			if err != nil {
+				util.LogErr("readActionLoop: json.Unmarshall", err)
+				continue
+			}
+			c.sendAction <- p
+		}
+	}
+}
 
-// 		for {
-// 			select {
-// 			case <-ctx.Done(): // write loop is closed
-// 				util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
-// 				return
-// 			case p := <-c.writeMessage: // message broker wants to write to client
-// 				c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 				bytes, err := json.Marshal(p)
-// 				if err != nil {
-// 					util.LogErr("writeMessageLoop json.Marshall", err)
-// 					continue
-// 				}
+// writeMessageLoop : writes messages to client if a message payload is passed
+// along c.writeMessage
+func (c *WebSocketClient) writeMessageLoop(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
-// 				err = c.connMessage.WriteMessage(websocket.TextMessage, bytes)
-// 				if err != nil {
-// 					return
-// 				}
+	for {
+		select {
+		case <-ctx.Done(): // write loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
+			return
+		case p := <-c.writeMessage: // message broker wants to write to client
+			c.connMessage.SetReadDeadline(time.Now().Add(2 * time.Second))
+			bytes, err := json.Marshal(p)
+			if err != nil {
+				util.LogErr("writeMessageLoop json.Marshall", err)
+				continue
+			}
 
-// 			case <-ticker.C: // send a ping to the connection if the ticker signals
-// 				c.connMessage.SetWriteDeadline(time.Now().Add(5 * time.Second))
-// 				err := c.connMessage.WriteMessage(websocket.PingMessage, []byte{})
-// 				if err != nil {
-// 					return
-// 				}
-// 			}
-// 		}
-// 	}
+			err = c.connMessage.WriteMessage(websocket.TextMessage, bytes)
+			if err != nil {
+				return
+			}
 
-// 	// writeActionLoop : writes actions to client if a action payload is passed
-// 	// along c.writeAction
-// 	func (c *WebSocketClient) writeActionLoop(ctx context.Context) {
-// 		ticker := time.NewTicker(1 * time.Second)
-// 		defer ticker.Stop()
+		case <-ticker.C: // send a ping to the connection if the ticker signals
+			c.connMessage.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			err := c.connMessage.WriteMessage(websocket.PingMessage, []byte{})
+			if err != nil {
+				return
+			}
+		}
+	}
+}
 
-// 		for {
-// 			select {
-// 			case <-ctx.Done(): // write loop is closed
-// 				util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
-// 				return
-// 			case p := <-c.writeAction: // message broker wants to write to client
-// 				c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
-// 				bytes, err := json.Marshal(p)
-// 				if err != nil {
-// 					util.LogErr("writeActionLoop json.Marshall", err)
-// 					continue
-// 				}
+// writeActionLoop : writes actions to client if a action payload is passed
+// along c.writeAction
+func (c *WebSocketClient) writeActionLoop(ctx context.Context) {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
 
-// 				err = c.connAction.WriteMessage(websocket.TextMessage, bytes)
-// 				if err != nil {
-// 					return
-// 				}
+	for {
+		select {
+		case <-ctx.Done(): // write loop is closed
+			util.LogInfo(fmt.Sprintf("client %s has terminated write loop", c.id))
+			return
+		case p := <-c.writeAction: // message broker wants to write to client
+			c.connAction.SetReadDeadline(time.Now().Add(2 * time.Second))
+			bytes, err := json.Marshal(p)
+			if err != nil {
+				util.LogErr("writeActionLoop json.Marshall", err)
+				continue
+			}
 
-// 			case <-ticker.C: // send a ping to the connection if the ticker signals
-// 				c.connAction.SetWriteDeadline(time.Now().Add(5 * time.Second))
-// 				err := c.connAction.WriteMessage(websocket.PingMessage, []byte{})
-// 				if err != nil {
-// 					return
-// 				}
-// 			}
-// 		}
-// 	}
+			err = c.connAction.WriteMessage(websocket.TextMessage, bytes)
+			if err != nil {
+				return
+			}
+
+		case <-ticker.C: // send a ping to the connection if the ticker signals
+			c.connAction.SetWriteDeadline(time.Now().Add(5 * time.Second))
+			err := c.connAction.WriteMessage(websocket.PingMessage, []byte{})
+			if err != nil {
+				return
+			}
+		}
+	}
+}

--- a/handler/helpers.go
+++ b/handler/helpers.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/calvinfeng/sling/model"
+	"github.com/calvinfeng/sling/util"
 	"github.com/jinzhu/gorm"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -18,12 +19,15 @@ func findUserByToken(db *gorm.DB, token string) (*model.User, error) {
 func findUserByCredentials(db *gorm.DB, c *Credential) (*model.User, error) {
 	var user model.User
 	if err := db.Where("name = ?", c.Username).First(&user).Error; err != nil {
+		util.LogErr("fail on fetch", err)
 		return nil, err
 	}
 
 	if err := bcrypt.CompareHashAndPassword(user.PasswordDigest, []byte(c.Password)); err != nil {
 		return nil, err
 	}
+
+	util.LogInfo("success on password")
 
 	return &user, nil
 }

--- a/handler/payloads.go
+++ b/handler/payloads.go
@@ -16,8 +16,8 @@ import (
 // MessagePayload holds the message content to be communicated from the
 // client frontend, to the server and message broker
 type MessagePayload struct {
-	userID string `json:"userID"`
-	roomID string `json:"roomID"`
+	userID uint   `json:"userID"`
+	roomID uint   `json:"roomID"`
 	time   string `json:"time"`
 	body   string `json:"body"`
 }
@@ -26,10 +26,10 @@ type MessagePayload struct {
 // client frontend, to the server and message broker
 type ActionPayload struct {
 	actionType  string `json:"actionType"`
-	userID      string `json:"userID"`
-	roomID      string `json:"roomID"`
-	newRoomID   string `json:"newRoomID"`
-	dmUserID    string `json:"dmUserID"`
+	userID      uint   `json:"userID"`
+	roomID      uint   `json:"roomID"`
+	newRoomID   uint   `json:"newRoomID"`
+	dmUserID    uint   `json:"dmUserID"`
 	newRoomName string `json:"newRoomName"`
 }
 
@@ -39,8 +39,8 @@ type ActionPayload struct {
 // message broker to users logged on
 type MessageResponsePayload struct {
 	messageType string `json:"messageType"`
-	userID      string `json:"userID"`
-	roomID      string `json:"roomID"`
+	userID      uint   `json:"userID"`
+	roomID      uint   `json:"roomID"`
 	time        string `json:"time"`
 	body        string `json:"body"`
 }
@@ -49,8 +49,8 @@ type MessageResponsePayload struct {
 // message broker to users logged on
 type ActionResponsePayload struct {
 	actionType     string           `json:"actionType"`
-	userID         string           `json:"userID"`
-	roomID         string           `json:"roomID"`
+	userID         uint             `json:"userID"`
+	roomID         uint             `json:"roomID"`
 	userName       string           `json:"userName"`
 	roomName       string           `json:"roomName"`
 	messageHistory []*model.Message `json:"messageHistory"`

--- a/handler/payloads.go
+++ b/handler/payloads.go
@@ -7,47 +7,51 @@ the MessageBroker and WebsocketClient s
 
 package handler
 
-// /************* Client to MessageBroker payload Types ******************/
+import (
+	"github.com/calvinfeng/sling/model"
+)
 
-// // MessagePayload holds the message content to be communicated from the
-// // client frontend, to the server and message broker
-// type MessagePayload struct {
-// 	userID string `json:"userID"`
-// 	roomID string `json:"roomID"`
-// 	time   string `json:"time"`
-// 	body   string `json:"body"`
-// }
+/************* Client to MessageBroker payload Types ******************/
 
-// // ActionPayload holds the action content to be communicated from the
-// // client frontend, to the server and message broker
-// type ActionPayload struct {
-// 	actionType  string `json:"actionType"`
-// 	userID      string `json:"userID"`
-// 	roomID      string `json:"roomID"`
-// 	newRoomID   string `json:"newRoomID"`
-// 	dmUserID    string `json:"dmUserID"`
-// 	newRoomName string `json:"newRoomName"`
-// }
+// MessagePayload holds the message content to be communicated from the
+// client frontend, to the server and message broker
+type MessagePayload struct {
+	userID string `json:"userID"`
+	roomID string `json:"roomID"`
+	time   string `json:"time"`
+	body   string `json:"body"`
+}
 
-// /***************** MessageBroker to Client payload Types *****************/
+// ActionPayload holds the action content to be communicated from the
+// client frontend, to the server and message broker
+type ActionPayload struct {
+	actionType  string `json:"actionType"`
+	userID      string `json:"userID"`
+	roomID      string `json:"roomID"`
+	newRoomID   string `json:"newRoomID"`
+	dmUserID    string `json:"dmUserID"`
+	newRoomName string `json:"newRoomName"`
+}
 
-// // MessageResponsePayload holds the message content to be communicated from the
-// // message broker to users logged on
-// type MessageResponsePayload struct {
-// 	messageType string `json:"messageType"`
-// 	userID      string `json:"userID"`
-// 	roomID      string `json:"roomID"`
-// 	time        string `json:"time"`
-// 	body        string `json:"body"`
-// }
+/***************** MessageBroker to Client payload Types *****************/
 
-// // ActionResponsePayload holds the message content to be communicated from the
-// // message broker to users logged on
-// type ActionResponsePayload struct {
-// 	actionType     string           `json:"actionType"`
-// 	userID         string           `json:"userID"`
-// 	roomID         string           `json:"roomID"`
-// 	userName       string           `json:"userName"`
-// 	roomName       string           `json:"roomName"`
-// 	messageHistory []*model.Message `json:"messageHistory"`
-// }
+// MessageResponsePayload holds the message content to be communicated from the
+// message broker to users logged on
+type MessageResponsePayload struct {
+	messageType string `json:"messageType"`
+	userID      string `json:"userID"`
+	roomID      string `json:"roomID"`
+	time        string `json:"time"`
+	body        string `json:"body"`
+}
+
+// ActionResponsePayload holds the message content to be communicated from the
+// message broker to users logged on
+type ActionResponsePayload struct {
+	actionType     string           `json:"actionType"`
+	userID         string           `json:"userID"`
+	roomID         string           `json:"roomID"`
+	userName       string           `json:"userName"`
+	roomName       string           `json:"roomName"`
+	messageHistory []*model.Message `json:"messageHistory"`
+}

--- a/handler/streams.go
+++ b/handler/streams.go
@@ -1,0 +1,108 @@
+package handler
+
+import (
+	"sync"
+)
+
+// GetActionStreamHandler handles stream messages - to be called after initializing your broker
+func GetActionStreamHandler(upgrader *websocket.Upgrader) echo.HandlerFunc { // handle message streams?
+	if broker == nil {
+		return nil, errors.New("please run you broker with RunBroker")
+	}
+
+	return func(ctx echo.Context) {
+		c = Credential{}
+		if err := ctx.Bind(c); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+
+		user, err := findUserByCredentials(db, c)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, "wrong username or password")
+		}
+
+		actionConn, err := upgrader.Upgrade(ctx.Response(), ctx.Request(), nil)
+		if err != nil {
+			return
+		}
+
+		// make host channel for other socket to pass connection to
+		broker.websocketsByUserID[user.ID] = make(chan *websocket.Conn)
+		// send actionConn along this channel
+		broker.websocketsByUserID[user.ID] <- actionConn
+
+	}, nil
+
+}
+
+// GetMessageStreamHandler handles stream messages - to be called after initializing your broker
+func GetMessageStreamHandler(upgrader *websocket.Upgrader) echo.HandlerFunc { // handle message streams?
+	if broker == nil {
+		return nil, errors.New("please run you broker with RunBroker")
+	}
+
+	return func(ctx echo.Context) {
+		c = Credential{}
+		if err := ctx.Bind(c); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+
+		user, err := findUserByCredentials(db, c)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, "wrong username or password")
+		}
+
+		messageConn, err := upgrader.Upgrade(ctx.Response(), ctx.Request(), nil)
+		if err != nil {
+			return
+		}
+
+		var actionConn *websocket.Conn = getActionConn(user.ID)
+
+		connectClient(messageConn, actionConn, user.ID)
+	}, nil
+
+}
+
+func connectClient(messageConn *websocket.Conn, actionConn *websocket.Conn, userID uint) {
+	defer messageConn.Close() // defer to execute after return
+	defer actionConn.Close()
+
+	cli := newWebSocketClient(messageConn, actionConn, userID)
+
+	broker.addClient <- cli //this will activate read/write loops
+
+	defer func() { // defer to execute after return
+		broker.removeClient <- cli
+	}()
+
+	util.LogInfo(fmt.Sprintf("client %s has joined the chatroom", cli.ID()))
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go cli.MessageListen(wg)
+	go cli.ActionListen(wg)
+	wg.Wait()
+
+	util.LogInfo(fmt.Sprintf("client %s has left the chatroom", cli.ID()))
+}
+
+// getActionConn : waits for action stream connection to be passed along channel
+// mapped by userID
+func getActionConn(userID uint) *websocket.Conn {
+	// TODO: set a timeout
+	for {
+		// wait for this users channel to be created
+		ch, ok := broker.websocketsByUserID[userID]
+		if ok {
+			// wait for the connection information to be sent
+			for {
+				select {
+				case actionConn := <-ch:
+					return actionConn
+				default:
+				}
+			}
+		}
+	}
+}

--- a/handler/user.go
+++ b/handler/user.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"github.com/calvinfeng/sling/util"
 	"net/http"
 	"strings"
 
@@ -96,6 +97,7 @@ func LoginHandler(db *gorm.DB) echo.HandlerFunc {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 
+		util.LogInfo(c.Username)
 		user, err := findUserByCredentials(db, c)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusUnauthorized, "wrong username or password")

--- a/handler/user.go
+++ b/handler/user.go
@@ -31,6 +31,7 @@ type (
 // NewUserHandler returns a handler that creates a new user.
 func NewUserHandler(db *gorm.DB /*, actions chan ActionPayload*/) echo.HandlerFunc {
 	return func(ctx echo.Context) error {
+
 		user := &model.User{}
 		if err := ctx.Bind(user); err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)

--- a/handler/user.go
+++ b/handler/user.go
@@ -21,6 +21,11 @@ type (
 		Password string `json:"password"`
 	}
 
+	// TokenCredential is a payload that captures user submitted token
+	TokenCredential struct {
+		Username string `json:"jwtToken"`
+	}
+
 	// TokenResponse is a payload that returns JWT token back to client.
 	TokenResponse struct {
 		Name     string `json:"name"`

--- a/handler/user.go
+++ b/handler/user.go
@@ -23,7 +23,7 @@ type (
 
 	// TokenCredential is a payload that captures user submitted token
 	TokenCredential struct {
-		Username string `json:"jwtToken"`
+		jwtToken string `json:"jwtToken"`
 	}
 
 	// TokenResponse is a payload that returns JWT token back to client.


### PR DESCRIPTION
Connected Message Broker and Websocket Clients with the websockets created by a user.

### Changes:
Created handlers for /api/stream/messages and /api/stream/actions that create an upgraded connection, and then wait for each other via channel communication, in order to create one client object with both connections. Also added Authorization.
Updated some of the overall error handling to be more informative.

### TODO:
Authentication is performed by sending a json of structure
```
{ "name":"namehere", "password":"passwordhere"}
```
but authentication should instead be performed using the jwt token.
```
{ "jwt_token":"longnumber21432158714751591"}
```