### PR TITLE
Delete extra actionhandlers file from handlers/ folder

### DIFF
--- a/handler/actionhandlers.go
+++ b/handler/actionhandlers.go
@@ -1,4 +1,0 @@
-package handler
-
-
-//Nonsense to allow merge


### PR DESCRIPTION
Fixing extra legacy file from last merge, where the file actionhandlers.go was moved from handlers/ to stream/.